### PR TITLE
Fix a byte-compile warning

### DIFF
--- a/tiktoken.el
+++ b/tiktoken.el
@@ -72,6 +72,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'subr-x)
 (require 'f)
 
 (defgroup tiktoken nil


### PR DESCRIPTION
```
In end of data:
tiktoken.el:331:38: Warning: the function ‘hash-table-keys’ is not known to be defined.
```